### PR TITLE
Load any FST script as sub-FST at runtime

### DIFF
--- a/Plugin_VIManager/Plugin_VIManager.cpp
+++ b/Plugin_VIManager/Plugin_VIManager.cpp
@@ -146,7 +146,35 @@ EXPORT void extProcMessage(MMDAgent *mmdagent, const char *type, const char *arg
             mmdagent->sendMessage(mid, MMDAGENT_EVENT_PLUGINDISABLE, "%s", PLUGINVIMANAGER_NAME);
          }
       } else if (MMDAgent_strequal(type, PLUGINVIMANAGER_LOADCOMMAND)) {
+         mmdagent->sendLogString(mid, MLOG_MESSAGE_CAPTURED, "%s|%s", type, args);
          vimanager_thread.reload(type, args);
+      } else if (MMDAgent_strequal(type, PLUGINVIMANAGER_SUB_COMMAND_START)) {
+         if (args) {
+            mmdagent->sendLogString(mid, MLOG_MESSAGE_CAPTURED, "%s|%s", type, args);
+            char *buff = MMDAgent_strdup(args);
+            char *save;
+            char *p1 = MMDAgent_strtok(buff, "|", &save);
+            char *p2 = MMDAgent_strtok(NULL, "|", &save);
+            if (p1 != NULL && p2 != NULL)
+               vimanager_thread.addSub(p1, p2);
+            free(buff);
+         }
+      } else if (MMDAgent_strequal(type, PLUGINVIMANAGER_SUB_COMMAND_STARTIF)) {
+         if (args) {
+            mmdagent->sendLogString(mid, MLOG_MESSAGE_CAPTURED, "%s|%s", type, args);
+            char *buff = MMDAgent_strdup(args);
+            char *save;
+            char *p1 = MMDAgent_strtok(buff, "|", &save);
+            char *p2 = MMDAgent_strtok(NULL, "|", &save);
+            if (p1 != NULL && p2 != NULL && MMDAgent_exist(p2))
+               vimanager_thread.addSub(p1, p2);
+            free(buff);
+         }
+      } else if (MMDAgent_strequal(type, PLUGINVIMANAGER_SUB_COMMAND_STOP)) {
+         if (args) {
+            mmdagent->sendLogString(mid, MLOG_MESSAGE_CAPTURED, "%s|%s", type, args);
+            vimanager_thread.delSub(args);
+         }
       } else if (vimanager_thread.isRunning()) {
          if (type != NULL) {
             vimanager_thread.enqueueBuffer(type, args); /* enqueue */

--- a/Plugin_VIManager/VIManager.cpp
+++ b/Plugin_VIManager/VIManager.cpp
@@ -583,6 +583,7 @@ void VIManager::initialize()
    for (int i = 0; i < VIMANAGER_HISTORY_LEN; i++)
       m_history[i] = NULL;
    m_historyPoint = 0;
+   m_end = false;
 }
 
 /* VIManager:clear: free VIManager */
@@ -1190,6 +1191,8 @@ bool VIManager::load(MMDAgent *mmdagent, int id, ZFileKey *key, const char *file
       m_mmdagent->sendLogString(m_id, MLOG_STATUS, "%u arcs, %u states", arc_count_total, c1 + c2);
    }
 
+   m_end = false;
+
    return ret;
 }
 
@@ -1221,8 +1224,10 @@ bool VIManager::transition(const char *itype, const InputArguments *iargs, char 
 
    /* state don't have arc list */
    arc_list = &m_currentState->arc_list;
-   if (arc_list->head == NULL)
+   if (arc_list->head == NULL) {
+      m_end = true;
       return false;
+   }
 
    /* match */
    for (arc = arc_list->head; arc != NULL; arc = arc->next) {
@@ -1347,4 +1352,22 @@ int VIManager::getTransitionHistory(VIManager_Arc **list, int maxlen)
    }
 
    return ret;
+}
+
+/* VIManager::getEndFlag: get end flag */
+bool VIManager::getEndFlag()
+{
+   return m_end;
+}
+
+/* VIManager::jumpToState: jump to the state if exist */
+bool VIManager::jumpToState(const char *state_label)
+{
+   VIManager_State *state;
+
+   state = VIManager_SList_findState(&m_stateList, state_label);
+   if (state == NULL)
+      return false;
+   m_currentState = state;
+   return true;
 }

--- a/Plugin_VIManager/VIManager.h
+++ b/Plugin_VIManager/VIManager.h
@@ -68,6 +68,7 @@
 #define VIMANAGER_REGEXP_BRACE '@'
 #define VIMANAGER_STATE_LABEL_MAXLEN 128
 #define VIMANAGER_HISTORY_LEN 128
+#define VIMANAGER_ATEXIST_STATE_LABEL "AT_EXIT"
 
 /* InputArguments: input for state transition */
 typedef struct _InputArguments {
@@ -145,6 +146,7 @@ private:
    VIManager_Arc *m_history[VIMANAGER_HISTORY_LEN]; /* transition history */
    int m_historyPoint; /* transition history entry point */
    std::mutex m_mutexHistory; /* mutex for history handling */
+   bool m_end;             /* true when reached a state with no arc */
 
    /* initialize: initialize VIManager */
    void initialize();
@@ -204,4 +206,10 @@ public:
 
    /* getTransitionHistory: get allocated list of transition history */
    int getTransitionHistory(VIManager_Arc **list, int maxlen);
+
+   /* getEndFlag: get end flag */
+   bool getEndFlag();
+
+   /* jumpToState: jump to the state if exist */
+   bool jumpToState(const char *state_label);
 };

--- a/Plugin_VIManager/VIManager_Thread.h
+++ b/Plugin_VIManager/VIManager_Thread.h
@@ -54,6 +54,12 @@
 /* POSSIBILITY OF SUCH DAMAGE.                                       */
 /* ----------------------------------------------------------------- */
 
+#define PLUGINVIMANAGER_SUB_COMMAND_START "SUBFST_START"
+#define PLUGINVIMANAGER_SUB_COMMAND_STARTIF "SUBFST_START_IF"
+#define PLUGINVIMANAGER_SUB_EVENT_START "SUBFST_EVENT_START"
+#define PLUGINVIMANAGER_SUB_COMMAND_STOP "SUBFST_STOP"
+#define PLUGINVIMANAGER_SUB_EVENT_STOP "SUBFST_EVENT_STOP"
+
 /* VIManager_Event: input message buffer */
 typedef struct _VIManager_Event {
    char *type;
@@ -69,7 +75,6 @@ typedef struct _VIManager_EventQueue {
 
 typedef struct _VIManager_Link {
    VIManager vim;
-   int id;
    struct _VIManager_Link *next;
 } VIManager_Link;
 
@@ -82,6 +87,7 @@ private:
    int m_id;
 
    GLFWmutex m_mutex;      /* mutex */
+   GLFWmutex m_mutex_sub;  /* mutex */
    GLFWcond m_cond;        /* condition variable */
    GLFWthread m_thread;    /* thread */
 
@@ -115,6 +121,15 @@ public:
 
    /* ~VIManager_Thread: thread destructor */
    ~VIManager_Thread();
+
+   /* addSub: add sub FST */
+   bool addSub(const char *label, const char *filename);
+
+   /* delSub: delete sub FST */
+   bool delSub(const char *label);
+
+   /* updateSubList: update sub list */
+   void updateSubList();
 
    /* loadAndStart: load FST and start thread */
    void loadAndStart(MMDAgent *mmdagent, int id, const char *file, const char *initial_state_label);


### PR DESCRIPTION
Extend VIManager to start / terminate arbitrary sub-FSTs at run time, and manage it.

New command messages:
- SUBFST_START
- SUBFST_START_IF
- SUBFST_STOP

New event messages:
- SUBFST_EVENT_START
- SUBFST_EVENT_STOP
