### PR TITLE
Fix: Prevent fp.h inclusion error on modern macOS systems

### DIFF
--- a/Library_libpng/src/pngpriv.h
+++ b/Library_libpng/src/pngpriv.h
@@ -518,7 +518,7 @@
 #  include <float.h>
 
 #  if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
-    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
+    defined(THINK_C) || defined(__SC__) || (defined(TARGET_OS_MAC) && !defined(__APPLE__))
    /* We need to check that <math.h> hasn't already been included earlier
     * as it seems it doesn't agree with <fp.h>, yet we should really use
     * <fp.h> if possible.


### PR DESCRIPTION
## Changes
- Modified the preprocessor condition to prevent including `fp.h` on modern macOS systems
- Added `!defined(__APPLE__)` check to the existing `TARGET_OS_MAC` condition

## Problem
On modern macOS systems, `fp.h` is not available. When the code attempts to include this header file, it results in a compilation error because the file cannot be found.
```
In file included from /Users/huyu/Develop/Huyu-MMDAgent-EX/Library_libpng/src/png.c:14:
/Users/huyu/Develop/Huyu-MMDAgent-EX/Library_libpng/src/pngpriv.h:527:16: fatal error: 'fp.h' file not found
  527 | #      include <fp.h>
      |                ^~~~~~
1 error generated.
make[2]: *** [Library_libpng/CMakeFiles/LIBPNG.dir/src/png.c.o] Error 1
make[1]: *** [Library_libpng/CMakeFiles/LIBPNG.dir/all] Error 2
make: *** [all] Error 2
```

## Solution
The fix adds an additional check to ensure `fp.h` is only included on older Mac systems where it is available. This is achieved by checking for `!defined(__APPLE__)` in addition to the existing `TARGET_OS_MAC` condition.

## Additional Notes
- While there might be alternative approaches to solve this issue, I believe this is the most straightforward and maintainable solution
- I'm not deeply familiar with C++ development, so I welcome any suggestions for alternative solutions
- I'm a native Japanese speaker, so please excuse any language issues in this PR description

## Testing
- Verified the fix works on my macOS systems
```
M1 MacBook Pro
macOS 15.5 (24F74)
Darwin 24.5.0
```
- Ensured backward compatibility with older systems

Please review and let me know if you have any questions or suggestions.
よろしくお願いいたします。