### PR TITLE
Fix failed INVALID_SOCKET evaluation on Windows

### DIFF
--- a/Plugin_Remote/ServerClient.cpp
+++ b/Plugin_Remote/ServerClient.cpp
@@ -206,7 +206,8 @@ bool ServerClient::readyAsServer(int portnum)
 #endif
   /* create socket */
 #ifdef WINSOCK
-   if((m_server_sd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP) == INVALID_SOCKET)) {
+   m_server_sd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+   if (m_server_sd == INVALID_SOCKET) {
       m_server_sd = SOCKET_INVALID;
       reset();
       return false;


### PR DESCRIPTION
# Problem
[Using MMDAgent-EX as Server via TCP/IP](https://mmdagent-ex.dev/docs/remote-tcpip/#case-1-mmdagent-ex-as-server) always fails on Windows due to an improper evaluation in the ``ServerClient::readyAsServer(int portnum)``.

## Root Cause
The current code at  [ServerClient.cpp#L209](https://github.com/mmdagent-ex/MMDAgent-EX/blob/05b0cc791d5d2fc43d28a249f85cfe7ac97f6d84/Plugin_Remote/ServerClient.cpp#L209)
```cpp
if((m_server_sd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP) == INVALID_SOCKET)) {
```
Due to operator precedence, == is evaluated before =, so this causes
1. The socket return value is compared with INVALID_SOCKET
2. The comparison result (typically 0 for false) is assigned to m_server_sd
3. m_server_sd gets an invalid value (0), causing subsequent setsockopt, bind, and listen calls to fail
4. The function almost always returns false, preventing the server from starting

# Steps to reproduce
1. Running the example by following [this docs](https://mmdagent-ex.dev/docs/run/)
2. Append these settings in ``./MMDAgent-EX/example/main.mdf`` 
```
Plugin_Remote_EnableServer=true
Plugin_Remote_ListenPort=50001
```
3. Open ``main.mdf`` with MMDAgent-EX
```
C:\path\to\MMDAgent-EX.exe C:\path\to\example\main.mdf
```
4. Get ``failed to open port 50001`` error even if this port is unused

# Solution
Change [ServerClient.cpp#L209](https://github.com/mmdagent-ex/MMDAgent-EX/blob/05b0cc791d5d2fc43d28a249f85cfe7ac97f6d84/Plugin_Remote/ServerClient.cpp#L209) like this:
```cpp
m_server_sd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
if (m_server_sd == INVALID_SOCKET) {
...
}
```
This change ensure results of ``socket`` assigns in ``m_server_sd``, and successfully evaluates whether it is ``INVALID_SOCKET`` or not. However, I’m not deeply familiar with C++ dev and sound synthesis, so this may not be the best approach for this application. 
# Tested Environment
Operating System: Windows 11
OS Version: 10.0.26200.7462
MMDAgent-EX Version: v2.1 Release

===========================

李　晃伸　先生
WindowsにおけるTCP/IPを用いた通信についてのPRを提出させて頂きます。
研究や授業等の準備でお忙しいところ恐縮ですが，ご確認いただけますと幸いです.